### PR TITLE
Change default dataTransferMode to bulk

### DIFF
--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
@@ -311,12 +311,7 @@ abstract class OpenAIServicesBase(override val uid: String) extends CognitiveSer
 
   override protected def getInternalTransformer(schema: StructType): PipelineModel = {
     if (PlatformDetails.runningOnFabric() && usingDefaultOpenAIEndpoint) {
-      try {
-        getModelStatus(getDeploymentName)
-      } catch {
-        case e: Throwable => logWarning(
-          "Could not get model status, you are likely running in the system context of Fabric", e)
-      }
+      assertModelStatus(getDeploymentName)
     }
     super.getInternalTransformer(schema)
   }

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAI.scala
@@ -109,7 +109,7 @@ trait HasOpenAITextParams extends HasOpenAISharedParams {
   val maxTokens: ServiceParam[Int] = new ServiceParam[Int](
     this, "maxTokens",
     "The maximum number of tokens to generate. Has minimum of 0.",
-    isRequired = false){
+    isRequired = false) {
     override val payloadName: String = "max_tokens"
   }
 
@@ -217,7 +217,7 @@ trait HasOpenAITextParams extends HasOpenAISharedParams {
   val cacheLevel: ServiceParam[Int] = new ServiceParam[Int](
     this, "cacheLevel",
     "can be used to disable any server-side caching, 0=no cache, 1=prompt prefix enabled, 2=full cache",
-    isRequired = false){
+    isRequired = false) {
     override val payloadName: String = "cache_level"
   }
 
@@ -233,7 +233,7 @@ trait HasOpenAITextParams extends HasOpenAISharedParams {
     this, "presencePenalty",
     "How much to penalize new tokens based on their existing frequency in the text so far." +
       " Decreases the likelihood of the model to repeat the same line verbatim. Has minimum of -2 and maximum of 2.",
-    isRequired = false){
+    isRequired = false) {
     override val payloadName: String = "presence_penalty"
   }
 
@@ -249,7 +249,7 @@ trait HasOpenAITextParams extends HasOpenAISharedParams {
     this, "frequencyPenalty",
     "How much to penalize new tokens based on whether they appear in the text so far." +
       " Increases the likelihood of the model to talk about new topics.",
-    isRequired = false){
+    isRequired = false) {
     override val payloadName: String = "frequency_penalty"
   }
 
@@ -265,7 +265,7 @@ trait HasOpenAITextParams extends HasOpenAISharedParams {
     this, "bestOf",
     "How many generations to create server side, and display only the best." +
       " Will not stream intermediate progress if best_of > 1. Has maximum value of 128.",
-    isRequired = false){
+    isRequired = false) {
     override val payloadName: String = "best_of"
   }
 
@@ -311,7 +311,12 @@ abstract class OpenAIServicesBase(override val uid: String) extends CognitiveSer
 
   override protected def getInternalTransformer(schema: StructType): PipelineModel = {
     if (PlatformDetails.runningOnFabric() && usingDefaultOpenAIEndpoint) {
-      getModelStatus(getDeploymentName)
+      try {
+        getModelStatus(getDeploymentName)
+      } catch {
+        case e: Throwable => logWarning(
+          "Could not get model status, you are likely running in the system context of Fabric", e)
+      }
     }
     super.getInternalTransformer(schema)
   }

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchSchemas.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/search/AzureSearchSchemas.scala
@@ -17,12 +17,12 @@ case class IndexInfo(
                     name: Option[String],
                     fields: Seq[IndexField],
                     suggesters: Option[Seq[String]],
-                    scoringProfiles: Option[Seq[String]],
+                    scoringProfiles: Option[Seq[ScoringProfile]],
                     analyzers: Option[Seq[String]],
                     charFilters: Option[Seq[String]],
                     tokenizers: Option[Seq[String]],
                     tokenFilters: Option[Seq[String]],
-                    defaultScoringProfile: Option[Seq[String]],
+                    defaultScoringProfile: Option[String],
                     corsOptions: Option[Seq[String]],
                     vectorSearch: Option[VectorSearch]
                     )
@@ -59,6 +59,41 @@ case class VectorColParams(
                           dimension: Int
                           )
 
+case class ScoringFunction(
+                          `type`: String,
+                          boost: Option[Double],
+                          fieldName: String,
+                          interpolation: Option[String],
+                          freshness: Option[FreshnessFunction],
+                          magnitude: Option[MagnitudeFunction],
+                          distance: Option[DistanceFunction],
+                          tag: Option[TagFunction]
+                          )
+
+case class FreshnessFunction(boostingDuration: String)
+
+case class MagnitudeFunction(
+                            boostingRangeStart: Double,
+                            boostingRangeEnd: Double,
+                            constantBoostBeyondRange: Option[Boolean]
+                            )
+
+case class DistanceFunction(
+                           referencePointParameter: String,
+                           boostingDistance: Double
+                           )
+
+case class TagFunction(tagsParameter: String)
+
+case class ScoringProfile(
+                         name: String,
+                         text: Option[TextWeights],
+                         functions: Option[Seq[ScoringFunction]],
+                         functionAggregation: Option[String]
+                         )
+
+case class TextWeights(weights: Map[String, Double])
+
 case class IndexStats(documentCount: Int, storageSize: Int)
 
 case class IndexList(`@odata.context`: String, value: Seq[IndexName])
@@ -71,6 +106,13 @@ object AzureSearchProtocol extends DefaultJsonProtocol {
     "dimensions", "vectorSearchConfiguration"))
   implicit val AcEnc: RootJsonFormat[AlgorithmConfigs] = jsonFormat2(AlgorithmConfigs.apply)
   implicit val VsEnc: RootJsonFormat[VectorSearch] = jsonFormat1(VectorSearch.apply)
+  implicit val FfEnc: RootJsonFormat[FreshnessFunction] = jsonFormat1(FreshnessFunction.apply)
+  implicit val MfEnc: RootJsonFormat[MagnitudeFunction] = jsonFormat3(MagnitudeFunction.apply)
+  implicit val DfEnc: RootJsonFormat[DistanceFunction] = jsonFormat2(DistanceFunction.apply)
+  implicit val TfEnc: RootJsonFormat[TagFunction] = jsonFormat1(TagFunction.apply)
+  implicit val SfEnc: RootJsonFormat[ScoringFunction] = jsonFormat8(ScoringFunction.apply)
+  implicit val TwEnc: RootJsonFormat[TextWeights] = jsonFormat1(TextWeights.apply)
+  implicit val SpEnc: RootJsonFormat[ScoringProfile] = jsonFormat4(ScoringProfile.apply)
   implicit val IiEnc: RootJsonFormat[IndexInfo] = jsonFormat11(IndexInfo.apply)
   implicit val IsEnc: RootJsonFormat[IndexStats] = jsonFormat2(IndexStats.apply)
   implicit val InEnc: RootJsonFormat[IndexName] = jsonFormat1(IndexName.apply)

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/text/TextAnalytics.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/text/TextAnalytics.scala
@@ -173,7 +173,8 @@ private[ml] abstract class TextAnalyticsBaseNoBinding(uid: String)
           getValueOpt(row, subscriptionKey),
           getValueOpt(row, AADToken),
           contentType(row),
-          getCustomAuthHeader(row)
+          getCustomAuthHeader(row),
+          getCustomHeaders(row)
         )
         val json = TARequest(makeDocuments(row)).toJson.compactPrint
         post.setEntity(new StringEntity(json, "UTF-8"))
@@ -646,7 +647,8 @@ class TextAnalyze(override val uid: String) extends TextAnalyticsBaseNoBinding(u
           getValueOpt(row, subscriptionKey),
           getValueOpt(row, AADToken),
           contentType(row),
-          getCustomAuthHeader(row)
+          getCustomAuthHeader(row),
+          getCustomHeaders(row)
         )
         val tasks = TextAnalyzeTasks(
           entityRecognitionTasks = getTaskHelper(getIncludeEntityRecognition, getEntityRecognitionParams),

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/translate/TextTranslator.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/translate/TextTranslator.scala
@@ -115,7 +115,8 @@ trait TextAsOnlyEntity extends HasTextInput with HasCognitiveServiceInput with H
           getValueOpt(row, subscriptionKey),
           getValueOpt(row, AADToken),
           contentType(row),
-          getCustomAuthHeader(row)
+          getCustomAuthHeader(row),
+          getCustomHeaders(row)
         )
         getValueOpt(row, subscriptionRegion).foreach(post.setHeader("Ocp-Apim-Subscription-Region", _))
 
@@ -259,7 +260,8 @@ class Translate(override val uid: String) extends TextTranslatorBase(uid)
           getValueOpt(row, subscriptionKey),
           getValueOpt(row, AADToken),
           contentType(row),
-          getCustomAuthHeader(row)
+          getCustomAuthHeader(row),
+          getCustomHeaders(row)
         )
         getValueOpt(row, subscriptionRegion).foreach(post.setHeader("Ocp-Apim-Subscription-Region", _))
 
@@ -550,7 +552,8 @@ class DictionaryExamples(override val uid: String) extends TextTranslatorBase(ui
             getValueOpt(row, subscriptionKey),
             getValueOpt(row, AADToken),
             contentType(row),
-            getCustomAuthHeader(row)
+            getCustomAuthHeader(row),
+            getCustomHeaders(row)
           )
           getValueOpt(row, subscriptionRegion).foreach(post.setHeader("Ocp-Apim-Subscription-Region", _))
 

--- a/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/vision/ComputerVision.scala
+++ b/cognitive/src/main/scala/com/microsoft/azure/synapse/ml/services/vision/ComputerVision.scala
@@ -86,7 +86,13 @@ trait HasImageInput extends HasImageUrl
       } else {
         val req = prepareMethod()
         req.setURI(new URI(rowToUrl(row)))
-        addHeaders(req, getValueOpt(row, subscriptionKey), getValueOpt(row, AADToken))
+        addHeaders(req,
+          getValueOpt(row, subscriptionKey),
+          getValueOpt(row, AADToken),
+          "",
+          getCustomAuthHeader(row),
+          getCustomHeaders(row)
+        )
         req match {
           case er: HttpEntityEnclosingRequestBase =>
             rowToEntity(row).foreach(er.setEntity)

--- a/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPromptSuite.scala
+++ b/cognitive/src/test/scala/com/microsoft/azure/synapse/ml/services/openai/OpenAIPromptSuite.scala
@@ -37,9 +37,12 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
 
   test("RAI Usage") {
     val result = prompt
-      .setDeploymentName(deploymentNameGpt4)
-      .setPromptTemplate("Tell me about a graphically disgusting movie in detail")
+      .setDeploymentName(deploymentNameGpt4o)
+      .setPromptTemplate("Tell me about a graphically disgusting " +
+        "and violent movie in detail, " +
+        "be very gory and NSFW in your description.")
       .transform(df)
+      .where(col(prompt.getErrorCol).isNotNull)
       .select(prompt.getErrorCol)
       .collect().head.getAs[Row](0)
     assert(Option(result).nonEmpty)
@@ -59,7 +62,7 @@ class OpenAIPromptSuite extends TransformerFuzzing[OpenAIPrompt] with OpenAIAPIK
 
   test("Basic Usage JSON") {
     prompt.setPromptTemplate(
-        """Split a word into prefix and postfix a respond in JSON
+        """Split a word into prefix and postfix a respond in JSON.
           |Cherry: {{"prefix": "Che", "suffix": "rry"}}
           |{text}:
           |""".stripMargin)

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/fabric/OpenAIFabricSetting.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/fabric/OpenAIFabricSetting.scala
@@ -18,39 +18,49 @@ trait OpenAIFabricSetting extends RESTUtils {
     usagePost(url, body, getHeaders);
   }
 
-  def getModelStatus(modelName: String): Boolean = {
+  def assertModelStatus(modelName: String): Unit = {
 
     val payload =
       s"""["${modelName}"]"""
 
     val mlWorkloadEndpointML = FabricClient.MLWorkloadEndpointML
     val url = mlWorkloadEndpointML + "cognitive/openai/tenantsetting"
-    val modelStatus = usagePost(url, payload).asJsObject.fields.get(modelName.toLowerCase).get
-
-    // Allowed, Disallowed, DisallowedForCrossGeo, ModelNotFound, InvalidResult
-    val resultString: String = modelStatus match {
-      case JsString(value) => value
-      case _ => throw new RuntimeException("Unexpected result from type conversion " +
-        "when checking the fabric tenant settings API.")
+    val modelStatusOpt: Option[JsValue] = try {
+      Some(usagePost(url, payload).asJsObject.fields.get(modelName.toLowerCase).get)
+    } catch {
+      case e: Throwable =>
+        println(
+          "Could not get model status, you are likely running in the system context of Fabric", e)
+        None
     }
 
-    resultString match {
-      case "Disallowed" => throw new RuntimeException(s"Default OpenAI model ${modelName} is Disallowed, " +
-        s"please contact your admin if you want to use default fabric LLM model. " +
-        s"Or you can set your Azure OpenAI credentials.")
-      case "DisallowedForCrossGeo" => throw new RuntimeException(s"Default OpenAI model ${modelName} is Disallowed " +
-        s"for Cross Geo, please contact your admin if you want to use default fabric LLM model. " +
-        s"Or you can set your Azure OpenAI credentials." +
-        s"Refer to https://learn.microsoft.com/en-us/fabric/data-science/ai-services/ai-services-overview " +
-        s"for more detials")
-      case "ModelNotFound" => throw new RuntimeException(s"Default OpenAI model ${modelName} not found, " +
-        s"please check your deployment name. " +
-        s"Refer to https://learn.microsoft.com/en-us/fabric/data-science/ai-services/ai-services-overview " +
-        s"for the models available.")
-      case "InvalidResult" => throw new RuntimeException("Cannot get tenant admin setting status correctly")
-      case "Allowed" => true
-      case _ => throw new RuntimeException("Unexpected result from checking the Fabric tenant settings API.")
+    modelStatusOpt.foreach { modelStatus =>
+      // Allowed, Disallowed, DisallowedForCrossGeo, ModelNotFound, InvalidResult
+      val resultString: String = modelStatus match {
+        case JsString(value) => value
+        case _ => throw new RuntimeException("Unexpected result from type conversion " +
+          "when checking the fabric tenant settings API.")
+      }
+
+      resultString match {
+        case "Disallowed" => throw new RuntimeException(s"Default OpenAI model ${modelName} is Disallowed, " +
+          s"please contact your admin if you want to use default fabric LLM model. " +
+          s"Or you can set your Azure OpenAI credentials.")
+        case "DisallowedForCrossGeo" => throw new RuntimeException(s"Default OpenAI model ${modelName} is Disallowed " +
+          s"for Cross Geo, please contact your admin if you want to use default fabric LLM model. " +
+          s"Or you can set your Azure OpenAI credentials." +
+          s"Refer to https://learn.microsoft.com/en-us/fabric/data-science/ai-services/ai-services-overview " +
+          s"for more detials")
+        case "ModelNotFound" => throw new RuntimeException(s"Default OpenAI model ${modelName} not found, " +
+          s"please check your deployment name. " +
+          s"Refer to https://learn.microsoft.com/en-us/fabric/data-science/ai-services/ai-services-overview " +
+          s"for the models available.")
+        case "InvalidResult" => throw new RuntimeException("Cannot get tenant admin setting status correctly")
+        case "Allowed" => ()
+        case _ => throw new RuntimeException("Unexpected result from checking the Fabric tenant settings API.")
+      }
     }
+
   }
 
 }

--- a/docs/Explore Algorithms/LightGBM/Overview.md
+++ b/docs/Explore Algorithms/LightGBM/Overview.md
@@ -164,11 +164,11 @@ SynapseML must pass data from Spark partitions to LightGBM native Datasets befor
 the actual LightGBM execution code for training and inference. SynapseML has two modes
 that control how this data is transferred: *streaming* and *bulk*.
 This mode doesn't affect training but can affect memory usage and overall fit/transform time.
+By default, SynapseML uses "streaming" mode.
 
 #### Bulk Execution mode
 The "Bulk" mode is older and requires accumulating all data in executor memory before creating Datasets. This mode can cause
 OOM errors for large data, especially since the data must be accumulated in its original uncompressed double-format size.
-For now, "bulk" mode is the default since "streaming" is new, but SynapseML will eventually make streaming the default.
 
 For bulk mode, native LightGBM Datasets can either be created per partition (useSingleDatasetMode=false), or
 per executor (useSingleDatasetMode=true). Generally, one Dataset per executor is more efficient since it reduces LightGBM network size and complexity during training or fitting. It also avoids using slow network protocols on partitions

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/LightGBMParams.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/LightGBMParams.scala
@@ -92,7 +92,7 @@ trait LightGBMExecutionParams extends Wrappable {
   val dataTransferMode = new Param[String](this, "dataTransferMode",
     "Specify how SynapseML transfers data from Spark to LightGBM.  " +
       "Values can be streaming, bulk. Default is bulk, which is the legacy mode.")
-  setDefault(dataTransferMode -> LightGBMConstants.StreamingDataTransferMode)
+  setDefault(dataTransferMode -> LightGBMConstants.BulkDataTransferMode)
   def getDataTransferMode: String = $(dataTransferMode)
   def setDataTransferMode(value: String): this.type = set(dataTransferMode, value)
 

--- a/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/LightGBMParams.scala
+++ b/lightgbm/src/main/scala/com/microsoft/azure/synapse/ml/lightgbm/params/LightGBMParams.scala
@@ -91,8 +91,8 @@ trait LightGBMExecutionParams extends Wrappable {
 
   val dataTransferMode = new Param[String](this, "dataTransferMode",
     "Specify how SynapseML transfers data from Spark to LightGBM.  " +
-      "Values can be streaming, bulk. Default is bulk, which is the legacy mode.")
-  setDefault(dataTransferMode -> LightGBMConstants.BulkDataTransferMode)
+      "Values can be streaming, bulk. Default is streaming.")
+  setDefault(dataTransferMode -> LightGBMConstants.StreamingDataTransferMode)
   def getDataTransferMode: String = $(dataTransferMode)
   def setDataTransferMode(value: String): this.type = set(dataTransferMode, value)
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.6.1
+sbt.version = 1.10.11


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

## What changes are proposed in this pull request?

The docs say that the default `dataTransferMode` is `streaming` but it was actually set to `bulk`, which is misleading. We just found this out over a long debugging session at work. 

I opted to keep the docs as they are and change the default to `streaming`. Do you think it's best to keep the default as `streaming` and update the docs accordingly instead? The [SynapseML website](https://microsoft.github.io/SynapseML/docs/Explore%20Algorithms/LightGBM/Overview/) also says that `bulk` is the default, but that in future `streaming` will become default.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.
- I haven't tested anything. I'm a python developer so I'm not really sure what to test here.

## Does this PR change any dependencies?

- [x] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [x] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
